### PR TITLE
Remove qDebug() from qt6ctplatformtheme.cpp

### DIFF
--- a/src/qt6ct-qtplugin/qt6ctplatformtheme.cpp
+++ b/src/qt6ct-qtplugin/qt6ctplatformtheme.cpp
@@ -114,7 +114,6 @@ QPlatformDialogHelper *Qt6CTPlatformTheme::createPlatformDialogHelper(DialogType
 
 const QPalette *Qt6CTPlatformTheme::palette(QPlatformTheme::Palette type) const
 {
-    qDebug() << Q_FUNC_INFO << type;
     return m_palette ? &*m_palette : QGenericUnixTheme::palette(type);
 }
 
@@ -141,7 +140,6 @@ QVariant Qt6CTPlatformTheme::themeHint(QPlatformTheme::ThemeHint hint) const
     case QPlatformTheme::SystemIconThemeName:
         return m_iconTheme;
     case QPlatformTheme::StyleNames:
-        qDebug() << Q_FUNC_INFO;
         return QStringList() << "qt6ct-style";
     case QPlatformTheme::IconThemeSearchPaths:
         return Qt6CT::iconPaths();


### PR DESCRIPTION
There's a few `qDebug()` calls leftover in `qt6ctplatformtheme.cpp`.

These trigger every time a QT6 program is run when using this theme, and prints about
20 lines that look like

```
virtual const QPalette* Qt6CTPlatformTheme::palette(QPlatformTheme::Palette) const QPlatformTheme::SystemPalette
virtual const QPalette* Qt6CTPlatformTheme::palette(QPlatformTheme::Palette) const QPlatformTheme::ToolButtonPalette
virtual const QPalette* Qt6CTPlatformTheme::palette(QPlatformTheme::Palette) const QPlatformTheme::ButtonPalette
```

When you're launching the program from a terminal window, this gets old fast. :grimacing: 

The calls could be replaced with `qCDebug(lqt6ct)`, but they don't look to be all that useful.


